### PR TITLE
Remove postCreateCommand

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -33,7 +33,7 @@
     "forwardPorts": [5000],
   
     // Use 'postCreateCommand' to run commands after the container is created.
-    "postCreateCommand": "npm install",
+    // "postCreateCommand": "npm install",
   
     // Configure tool-specific properties.
     "customizations": {


### PR DESCRIPTION
This pull request includes a change to the `.devcontainer/devcontainer.json` file. The `postCreateCommand` that previously ran `npm install` after the container was created has been commented out.