### PR TITLE
Update gpt-35-turbo model

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -62,7 +62,7 @@ module openAi1 'core/ai/cognitiveservices.bicep' = {
         model: {
           format: 'OpenAI'
           name: 'gpt-35-turbo'
-          version: '0613'
+          version: '0125'
         }
         sku: {
           name: 'Standard'
@@ -92,7 +92,7 @@ module openAi2 'core/ai/cognitiveservices.bicep' = {
         model: {
           format: 'OpenAI'
           name: 'gpt-35-turbo'
-          version: '0613'
+          version: '0125'
         }
         sku: {
           name: 'Standard'


### PR DESCRIPTION
This pull request includes changes to the `infra/main.bicep` file to update the model version for two OpenAI modules. The key changes are to update the model version since 0613 is legacy and deprecated

* Updated the `version` field from `'0613'` to `'0125'` for the `openAi1` module.
* Updated the `version` field from `'0613'` to `'0125'` for the `openAi2` module.0613 has been deprecated